### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/dax/sorted-groups/compare/v0.1.0...v0.1.1) - 2024-12-18
+
+### Other
+
+- Add changelog file
+
 ## [0.1.0](https://github.com/dax/slack-blocks-render/releases/tag/v0.1.0) - 2024-12-18
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "sorted-groups"
-version = "0.1.0"
+version = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sorted-groups"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["David Rousselie <david@rousselie.name>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `sorted-groups`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/dax/sorted-groups/compare/v0.1.0...v0.1.1) - 2024-12-18

### Other

- Add changelog file
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).