### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/dax/sorted-groups/compare/v0.1.1...v0.2.0) - 2024-12-18
+
+### Fixed
+
+- Use simpler data structure definition
+
 ## [0.1.1](https://github.com/dax/sorted-groups/compare/v0.1.0...v0.1.1) - 2024-12-18
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "sorted-groups"
-version = "0.1.1"
+version = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sorted-groups"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["David Rousselie <david@rousselie.name>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `sorted-groups`: 0.1.1 -> 0.2.0 (⚠️ API breaking changes)

### ⚠️ `sorted-groups` breaking changes

```
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/inherent_method_missing.ron

Failed in:
  SortedGroups::from_iter, previously in file /tmp/.tmplB1mdL/sorted-groups/src/lib.rs:68
  SortedGroups::insert, previously in file /tmp/.tmplB1mdL/sorted-groups/src/lib.rs:76

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/method_parameter_count_changed.ron

Failed in:
  sorted_groups::SortedGroups::new now takes 2 parameters instead of 1, in /tmp/.tmpgsOnDp/sorted-groups/src/lib.rs:60
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/dax/sorted-groups/compare/v0.1.1...v0.2.0) - 2024-12-18

### Fixed

- Use simpler data structure definition
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).